### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,8 +20,6 @@ When this asks you which packages you want to install, search for and add `git`.
 
 image::gitpack.png[]
 
-Ensure you have the JDK for Java 8, you could use http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html[this].
-
 Open Intelij or your https://en.wikipedia.org/wiki/Integrated_development_environment[IDE], or https://www.jetbrains.com/idea/download/#section=windows[install Intelij] first if you haven't already.
 Intelij is used for this tutorial.
 


### PR DESCRIPTION
IntelliJ now downloads the JDK so you don't need to install the JDK first