### PR TITLE
Remove old check.thread.safety property

### DIFF
--- a/benchmarks/system.properties
+++ b/benchmarks/system.properties
@@ -1,5 +1,4 @@
 # Tracing if resources are closed/released correctly.
 jvm.resource.tracing=false
-check.thread.safety=true
 # for profiling
 jvm.safepoint.enabled=true

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
-        <version>1.24.0-SNAPSHOT</version>
+        <version>1.24.0</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
The check.thread.saftety property has not been used for a while. Removing references to it.